### PR TITLE
Add useDocumentTitle hook and update document titles

### DIFF
--- a/src/hooks/useDocumentTitle.js
+++ b/src/hooks/useDocumentTitle.js
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+export function useDocumentTitle(title) {
+  useEffect(() => {
+    document.title = `${title} | Künefe SKS`;
+
+    return () => {
+      document.title = 'Künefe SKS';
+    };
+  }, [title]);
+}

--- a/src/pages/Clubs/ClubsComp.jsx
+++ b/src/pages/Clubs/ClubsComp.jsx
@@ -1,10 +1,11 @@
 import { Clubs, ClubsAlt, InnerContainer } from './ClubsComp-styled';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '../../hooks/useQuery';
 import PropTypes from 'prop-types';
 import { searchData } from '../../utils/searchData';
 import { DUMMY_DATA_CLUBS as DUMMY_DATA } from '../../data/clubs';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 
 function SearchIcon() {
   return (
@@ -106,9 +107,7 @@ function ClubsComp() {
 
   const filteredData = searchData(DUMMY_DATA, searchQuery);
 
-  useEffect(() => {
-    document.title = 'Clubs | Künefe SKS';
-  }, []);
+  useDocumentTitle('Clubs');
 
   function onChangeHandler(e) {
     setSearchQuery(e.target.value);

--- a/src/pages/Home/HomeComp.jsx
+++ b/src/pages/Home/HomeComp.jsx
@@ -1,12 +1,10 @@
-import { useEffect } from 'react';
 import Hero from './components/Hero/HeroComp';
 import Clubs from './components/Clubs/ClubsComp';
 import Recents from './components/Recents/RecentsComp';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 
 function HomeComp() {
-  useEffect(() => {
-    document.title = 'Home | Künefe SKS';
-  }, []);
+  useDocumentTitle('Home');
 
   return (
     <>


### PR DESCRIPTION
This pull request adds a new custom hook called useDocumentTitle and updates the document titles in the ClubsComp and HomeComp components. The useDocumentTitle hook allows for easy management of document titles in React components.